### PR TITLE
Fix select_t1 according to spec

### DIFF
--- a/ax25/ax25_dl.c
+++ b/ax25/ax25_dl.c
@@ -575,7 +575,7 @@ static void invoke_retransmission(ax25_dl_event_t *ev) {
 }
 
 static void select_t1(ax25_dl_event_t *ev) {
-    if (ev->conn->rc) {
+    if (ev->conn->rc == 0) {
         duration_t srtt = duration_mul(ev->conn->srtt, 7);
         srtt = duration_add(srtt, ev->conn->t1v);
         srtt = duration_sub(srtt, ev->conn->t1_remaining);


### PR DESCRIPTION
1998 spec page 109 and 2017 spec page 102 both check for rc == 0 for the bigger formula, not the opposite.

Unless you know something I don't. :-)